### PR TITLE
Fix node object assignment and merging

### DIFF
--- a/mrblib/mitamae/node.rb
+++ b/mrblib/mitamae/node.rb
@@ -33,7 +33,7 @@ module MItamae
 
     def method_missing(method, *args)
       if @mash.respond_to?(method)
-        return @mash.public_send(method, *args)
+        return @mash.send(method, *args)
       elsif args.empty? && value = fetch_inventory_value(method)
         return value
       end

--- a/spec/integration/node_spec.rb
+++ b/spec/integration/node_spec.rb
@@ -14,4 +14,14 @@ describe 'node object' do
     it { should be_file }
     its(:content) { should eq('node.yml') }
   end
+
+  describe file('/tmp/node_assign') do
+    it { should be_file }
+    its(:content) { should eq("hello: hello\nworld: world\n") }
+  end
+
+  describe file('/tmp/node_merge') do
+    it { should be_file }
+    its(:content) { should eq("hello: hello\nworld: world\n" * 2) }
+  end
 end

--- a/spec/recipes/node.rb
+++ b/spec/recipes/node.rb
@@ -5,3 +5,7 @@ end
 file '/tmp/node_yml' do
   content node[:node_yml]
 end
+
+template '/tmp/node_assign'
+
+template '/tmp/node_merge'

--- a/spec/recipes/templates/tmp/node_assign.erb
+++ b/spec/recipes/templates/tmp/node_assign.erb
@@ -1,0 +1,4 @@
+<%- node.merge!(node_assign: 'hello') -%>
+hello: <%= node[:node_assign] %>
+<%- node[:node_assign] = 'world' -%>
+world: <%= node[:node_assign] %>

--- a/spec/recipes/templates/tmp/node_merge.erb
+++ b/spec/recipes/templates/tmp/node_merge.erb
@@ -1,0 +1,7 @@
+<%- node.reverse_merge!(node_merge_a: 'hello', nest: { node_merge_b: 'world' }) -%>
+hello: <%= node[:node_merge_a] %>
+world: <%= node[:nest][:node_merge_b] %>
+<%- node.merge!(nest: { node_merge_b: 'hello' }) -%>
+<%- node.reverse_merge!(nest: { node_merge_b: 'world', node_merge_c: 'world' }) -%>
+hello: <%= node[:nest][:node_merge_b] %>
+world: <%= node[:nest][:node_merge_c] %>


### PR DESCRIPTION
Fixed the following problem.

```rb
node[:a] #=> nil
node[:b] #=> nil

node[:a] = 'hello'
node.merge!(b: 'world')

node[:a] #=> nil
node[:b] #=> nil
```

Thank you for reporting this! @rosylilly