### PR TITLE
Add pre_action hook

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "mruby"]
 	path = mruby
-	url = https://github.com/mruby/mruby
+	url = https://github.com/k0kubun/mruby

--- a/mrblib/mitamae/resource/base.rb
+++ b/mrblib/mitamae/resource/base.rb
@@ -47,6 +47,7 @@ module MItamae
           ResourceContext.new(self, variables).instance_exec(&block)
         end
         process_attributes
+        @attributes.freeze
       end
 
       def resource_type

--- a/mrblib/mitamae/resource_executor/base.rb
+++ b/mrblib/mitamae/resource_executor/base.rb
@@ -51,10 +51,10 @@ module MItamae
 
         MItamae.logger.with_indent_if(MItamae.logger.debug?) do
           MItamae.logger.debug '(in set_desired_attributes)'
-          desired = desired_attributes(action)
+          desired = desired_attributes(action).freeze
 
           MItamae.logger.debug '(in set_current_attributes)'
-          current = current_attributes(action)
+          current = current_attributes(action).freeze
 
           MItamae.logger.debug '(in pre_action)'
           pre_action(current, desired)

--- a/mrblib/mitamae/resource_executor/base.rb
+++ b/mrblib/mitamae/resource_executor/base.rb
@@ -50,12 +50,14 @@ module MItamae
         MItamae.logger.debug "#{@resource.resource_type}[#{@resource.resource_name}] action: #{action}"
 
         MItamae.logger.with_indent_if(MItamae.logger.debug?) do
-          # The (in *) logging is just for backward compatibility with original MItamae.
-          MItamae.logger.debug '(in pre_action)'
+          MItamae.logger.debug '(in set_desired_attributes)'
           desired = desired_attributes(action)
 
           MItamae.logger.debug '(in set_current_attributes)'
           current = current_attributes(action)
+
+          MItamae.logger.debug '(in pre_action)'
+          pre_action(current, desired)
 
           MItamae.logger.debug '(in show_differences)'
           show_differences(current, desired)
@@ -131,6 +133,12 @@ module MItamae
 
       def set_desired_attributes(desired, action)
         raise NotImplementedError
+      end
+
+      # All destructive operations before `show_differences` should be put here,
+      # not in `set_desired_attributes` or `set_current_attributes`.
+      def pre_action(current, desired)
+        # Override this if necessary.
       end
 
       def run_command(*args)

--- a/mrblib/mitamae/resource_executor/directory.rb
+++ b/mrblib/mitamae/resource_executor/directory.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class Directory < Base
-      def apply(_, desired)
+      def apply
         if desired.exist
           if !run_specinfra(:check_file_is_directory, desired.path)
             run_specinfra(:create_file_as_directory, desired.path)

--- a/mrblib/mitamae/resource_executor/directory.rb
+++ b/mrblib/mitamae/resource_executor/directory.rb
@@ -28,6 +28,7 @@ module MItamae
 
           if current.exist
             current.mode = run_specinfra(:get_file_mode, attributes.path).stdout.chomp
+            current.mode = normalize_mode(current.mode)
             current.owner = run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
             current.group = run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
           else
@@ -45,17 +46,11 @@ module MItamae
         when :delete
           desired.exist = false
         end
+        desired.mode = normalize_mode(desired.mode) if desired.mode
       end
 
       def normalize_mode(mode)
         sprintf("%4s", mode).gsub(/ /, '0')
-      end
-
-      def show_differences(current, desired)
-        current.mode = normalize_mode(current.mode) if current.mode
-        desired.mode = normalize_mode(desired.mode) if desired.mode
-
-        super
       end
     end
   end

--- a/mrblib/mitamae/resource_executor/execute.rb
+++ b/mrblib/mitamae/resource_executor/execute.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class Execute < Base
-      def apply(_, desired)
+      def apply
         if desired.executed
           run_command(desired.command)
           updated!

--- a/mrblib/mitamae/resource_executor/file.rb
+++ b/mrblib/mitamae/resource_executor/file.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class File < Base
-      def apply(current, desired)
+      def apply
         if desired.exist
           if !current.exist && !@temppath
             run_command(["touch", attributes.path])
@@ -71,38 +71,38 @@ module MItamae
         desired.mode = normalize_mode(desired.mode) if desired.mode
       end
 
-      def pre_action(current, desired)
-        send_tempfile(desired)
-        compare_file(current)
+      def pre_action
+        send_tempfile
+        compare_file
       end
 
       def normalize_mode(mode)
         sprintf("%4s", mode).gsub(/ /, '0')
       end
 
-      def show_differences(current, desired)
+      def show_differences
         super
 
         if @temppath && desired.exist
-          show_content_diff(current)
+          show_content_diff
         end
       end
 
-      def compare_to(current)
+      def compare_to
         if current.exist
-          attributes.path
+          desired.path
         else
           '/dev/null'
         end
       end
 
-      def compare_file(current)
+      def compare_file
         @modified = false
         unless @temppath
           return
         end
 
-        case run_command(["diff", "-q", compare_to(current), @temppath], error: false).exit_status
+        case run_command(["diff", "-q", compare_to, @temppath], error: false).exit_status
         when 1
           # diff found
           @modified = true
@@ -112,10 +112,10 @@ module MItamae
         end
       end
 
-      def show_content_diff(current)
+      def show_content_diff
         if @modified
           MItamae.logger.info "diff:"
-          diff = run_command(["diff", "-u", compare_to(current), @temppath], error: false)
+          diff = run_command(["diff", "-u", compare_to, @temppath], error: false)
           diff.stdout.each_line do |line|
             color = if line.start_with?('+')
                       :green
@@ -139,7 +139,7 @@ module MItamae
         nil
       end
 
-      def send_tempfile(desired)
+      def send_tempfile
         if !desired.content && !content_file
           @temppath = nil
           return

--- a/mrblib/mitamae/resource_executor/file.rb
+++ b/mrblib/mitamae/resource_executor/file.rb
@@ -41,6 +41,7 @@ module MItamae
         current.exist = FileTest.exist?(attributes.path)
         if current.exist
           current.mode = run_specinfra(:get_file_mode, attributes.path).stdout.chomp
+          current.mode = normalize_mode(current.mode)
           current.owner = run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
           current.group = run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
         else
@@ -67,6 +68,7 @@ module MItamae
             desired.content = content
           end
         end
+        desired.mode = normalize_mode(desired.mode) if desired.mode
       end
 
       def pre_action(current, desired)
@@ -79,9 +81,6 @@ module MItamae
       end
 
       def show_differences(current, desired)
-        current.mode = normalize_mode(current.mode) if current.mode
-        desired.mode = normalize_mode(desired.mode) if desired.mode
-
         super
 
         if @temppath && desired.exist

--- a/mrblib/mitamae/resource_executor/gem_package.rb
+++ b/mrblib/mitamae/resource_executor/gem_package.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class GemPackage < Base
-      def apply(current, desired)
+      def apply
         if desired.installed
           if current.installed
             if desired.version && current.version != desired.version

--- a/mrblib/mitamae/resource_executor/git.rb
+++ b/mrblib/mitamae/resource_executor/git.rb
@@ -3,7 +3,7 @@ module MItamae
     class Git < Base
       DEPLOY_BRANCH = "deploy"
 
-      def apply(_, desired)
+      def apply
         ensure_git_available
 
         new_repository = false

--- a/mrblib/mitamae/resource_executor/group.rb
+++ b/mrblib/mitamae/resource_executor/group.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class Group < Base
-      def apply(current, desired)
+      def apply
         if desired.exist
           if exist?(desired.groupname)
             if desired.gid && desired.gid != current.gid

--- a/mrblib/mitamae/resource_executor/http_request.rb
+++ b/mrblib/mitamae/resource_executor/http_request.rb
@@ -4,14 +4,8 @@ module MItamae
       private
 
       def set_desired_attributes(desired, action)
-        # https://github.com/itamae-kitchen/itamae/blob/v1.9.9/lib/itamae/resource/file.rb#L15
-        @existed = FileTest.exist?(desired.path)
-
         desired.exist = true
         desired.content = fetch_content(desired)
-
-        send_tempfile(desired)
-        compare_file
       end
 
       def fetch_content(desired)

--- a/mrblib/mitamae/resource_executor/link.rb
+++ b/mrblib/mitamae/resource_executor/link.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class Link < Base
-      def apply(_, desired)
+      def apply
         unless run_specinfra(:check_file_is_linked_to, desired.link, desired.to)
           run_specinfra(:link_file_to, desired.link, desired.to, force: desired.force)
         end

--- a/mrblib/mitamae/resource_executor/local_ruby_block.rb
+++ b/mrblib/mitamae/resource_executor/local_ruby_block.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class LocalRubyBlock < Base
-      def apply(_, desired)
+      def apply
         desired.block.call
       end
 

--- a/mrblib/mitamae/resource_executor/package.rb
+++ b/mrblib/mitamae/resource_executor/package.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class Package < Base
-      def apply(current, desired)
+      def apply
         if desired.installed
           unless run_specinfra(:check_package_is_installed, desired.name, desired.version)
             run_specinfra(:install_package, desired.name, desired.version, desired.options)

--- a/mrblib/mitamae/resource_executor/remote_directory.rb
+++ b/mrblib/mitamae/resource_executor/remote_directory.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class RemoteDirectory < Base
-      def apply(_, desired)
+      def apply
         if desired.exist
           if FileTest.directory?(desired.path)
             run_specinfra(:remove_file, desired.path)
@@ -55,7 +55,7 @@ module MItamae
         sprintf("%4s", mode).gsub(/ /, '0')
       end
 
-      def show_differences(current, desired)
+      def show_differences
         super
 
         if current.exist

--- a/mrblib/mitamae/resource_executor/remote_directory.rb
+++ b/mrblib/mitamae/resource_executor/remote_directory.rb
@@ -30,6 +30,7 @@ module MItamae
 
           if current.exist
             current.mode = run_specinfra(:get_file_mode, attributes.path).stdout.chomp
+            current.mode = normalize_mode(current.mode)
             current.owner = run_specinfra(:get_file_owner_user, attributes.path).stdout.chomp
             current.group = run_specinfra(:get_file_owner_group, attributes.path).stdout.chomp
           else
@@ -47,6 +48,7 @@ module MItamae
         when :delete
           desired.exist = false
         end
+        desired.mode = normalize_mode(desired.mode) if desired.mode
       end
 
       def normalize_mode(mode)
@@ -54,9 +56,6 @@ module MItamae
       end
 
       def show_differences(current, desired)
-        current.mode = normalize_mode(current.mode) if current.mode
-        desired.mode = normalize_mode(desired.mode) if desired.mode
-
         super
 
         if current.exist

--- a/mrblib/mitamae/resource_executor/service.rb
+++ b/mrblib/mitamae/resource_executor/service.rb
@@ -6,7 +6,7 @@ module MItamae
         @under = attributes.provider ? "_under_#{attributes.provider}" : ""
       end
 
-      def apply(current, desired)
+      def apply
         if desired.has_key?(:running)
           if desired.running && !current.running
             run_specinfra(:"start_service#{@under}", attributes.name)

--- a/mrblib/mitamae/resource_executor/user.rb
+++ b/mrblib/mitamae/resource_executor/user.rb
@@ -1,7 +1,7 @@
 module MItamae
   module ResourceExecutor
     class User < Base
-      def apply(current, desired)
+      def apply
         if desired.exist
           if current.exist
             if desired.uid && desired.uid != current.uid


### PR DESCRIPTION
Add `pre_action` hook and change the roles of hook methods in resource_executor.

- `set_current_attributes` and `set_desired_attributes` should be pure.
  - Because current file resource's `set_desired_attributes` has a destructive operation, `set_current_attributes` depends on that it is called after `set_desired_attributes`. Current `current`/`desired` design fails at that point.
- Destructive operations should be put in `pre_action` hook.