### PR TITLE
Add InlineBackend and run check_file_is_directory with it

### DIFF
--- a/mrblib/mitamae/cli/local.rb
+++ b/mrblib/mitamae/cli/local.rb
@@ -33,7 +33,8 @@ module MItamae
           backend:   backend,
         ).load(@recipe_paths)
 
-        runner = Runner.new(dry_run: @options[:dry_run], backend: backend)
+        inline_backend = InlineBackend.new
+        runner = Runner.new(dry_run: @options[:dry_run], backend: backend, inline_backend: inline_backend)
         RecipeExecutor.new(runner).execute(recipes)
       end
 

--- a/mrblib/mitamae/inline_backend.rb
+++ b/mrblib/mitamae/inline_backend.rb
@@ -1,0 +1,13 @@
+module MItamae
+  class InlineBackend
+    def initialize
+      @backends = InlineBackends.constants.sort.map do |class_name|
+        InlineBackends.const_get(class_name).new
+      end
+    end
+
+    def find_backend(type, *args)
+      @backends.find { |b| b.runnable?(type, *args) }
+    end
+  end
+end

--- a/mrblib/mitamae/inline_backends/file_backend.rb
+++ b/mrblib/mitamae/inline_backends/file_backend.rb
@@ -1,0 +1,17 @@
+module MItamae
+  module InlineBackends
+    class FileBackend
+      def runnable?(type, *args)
+        respond_to?(type)
+      end
+
+      def run(type, *args)
+        send(type, *args)
+      end
+
+      def check_file_is_directory(path)
+        FileTest.directory?(path)
+      end
+    end
+  end
+end

--- a/mrblib/mitamae/resource_executor/base.rb
+++ b/mrblib/mitamae/resource_executor/base.rb
@@ -163,12 +163,17 @@ module MItamae
       end
 
       def run_specinfra(type, *args)
-        command = @runner.get_command(type, *args)
-
-        if type.to_s.start_with?('check_')
-          check_command(command)
+        inline_backend = @runner.find_inline_backend(type, *args)
+        if inline_backend
+          inline_backend.run(type, *args)
         else
-          run_command(command)
+          command = @runner.get_command(type, *args)
+
+          if type.to_s.start_with?('check_')
+            check_command(command)
+          else
+            run_command(command)
+          end
         end
       end
 

--- a/mrblib/mitamae/runner.rb
+++ b/mrblib/mitamae/runner.rb
@@ -3,6 +3,7 @@ module MItamae
   class Runner
     def initialize(options)
       @backend = options.fetch(:backend)
+      @inline_backend = options.fetch(:inline_backend)
       @dry_run = options.fetch(:dry_run)
     end
 
@@ -16,6 +17,10 @@ module MItamae
 
     def get_command(*args)
       @backend.get_command(*args)
+    end
+
+    def find_inline_backend(type, *args)
+      @inline_backend.find_backend(type, *args)
     end
   end
 end


### PR DESCRIPTION
It improves performance because it skips `test -d`. External command
invocations are slow operations compared to just calling syscalls in the
same process.

Before

```
% cat test.rb
directory '/tmp/hello' do
  owner 'eagletmt'
  group 'staff'
  mode '755'
end
% mitamae local test.rb -l debug
 INFO : Starting MItamae...
 INFO : Recipe: /home/eagletmt/.ghq/github.com/k0kubun/mitamae/test.rb
DEBUG :   directory[/tmp/hello]
DEBUG :     directory[/tmp/hello] action: create
DEBUG :       (in set_desired_attributes)
DEBUG :       (in set_current_attributes)
DEBUG :       Executing `test -d /tmp/hello`...
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %a /tmp/hello`...
DEBUG :         stdout | 755
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %U /tmp/hello`...
DEBUG :         stdout | eagletmt
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %G /tmp/hello`...
DEBUG :         stdout | staff
DEBUG :         exited with 0
DEBUG :       (in pre_action)
DEBUG :       (in show_differences)
DEBUG :       directory[/tmp/hello] exist will not change (current value is 'true')
DEBUG :       directory[/tmp/hello] mode will not change (current value is '0755')
DEBUG :       directory[/tmp/hello] owner will not change (current value is 'eagletmt')
DEBUG :       directory[/tmp/hello] group will not change (current value is 'staff')
DEBUG :       Executing `test -d /tmp/hello`...
DEBUG :         exited with 0
DEBUG :       Executing `chmod  0755 /tmp/hello`...
DEBUG :         exited with 0
DEBUG :       Executing `chown  eagletmt:staff /tmp/hello`...
DEBUG :         exited with 0
```

After

```
% mitamae local test.rb -l debug
 INFO : Starting MItamae...
 INFO : Recipe: /home/eagletmt/.ghq/github.com/k0kubun/mitamae/test.rb
DEBUG :   directory[/tmp/hello]
DEBUG :     directory[/tmp/hello] action: create
DEBUG :       (in set_desired_attributes)
DEBUG :       (in set_current_attributes)
DEBUG :       Executing `stat -c %a /tmp/hello`...
DEBUG :         stdout | 755
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %U /tmp/hello`...
DEBUG :         stdout | eagletmt
DEBUG :         exited with 0
DEBUG :       Executing `stat -c %G /tmp/hello`...
DEBUG :         stdout | staff
DEBUG :         exited with 0
DEBUG :       (in pre_action)
DEBUG :       (in show_differences)
DEBUG :       directory[/tmp/hello] exist will not change (current value is 'true')
DEBUG :       directory[/tmp/hello] mode will not change (current value is '0755')
DEBUG :       directory[/tmp/hello] owner will not change (current value is 'eagletmt')
DEBUG :       directory[/tmp/hello] group will not change (current value is 'staff')
DEBUG :       Executing `chmod  0755 /tmp/hello`...
DEBUG :         exited with 0
DEBUG :       Executing `chown  eagletmt:staff /tmp/hello`...
DEBUG :         exited with 0
```