### PR TITLE
Let exceptions go up

### DIFF
--- a/mrblib/mitamae/inline_backends/file_backend.rb
+++ b/mrblib/mitamae/inline_backends/file_backend.rb
@@ -16,24 +16,18 @@ module MItamae
       def get_file_mode(path)
         mode_str = sprintf('%04o', File.stat(path).mode & 07777)
         Specinfra::CommandResult.new(stdout: mode_str, stderr: '', exit_status: 0)
-      rescue => e
-        Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
 
       def get_file_owner_user(path)
         uid = File.stat(path).uid
         passwd = Etc.getpwuid(uid)
         Specinfra::CommandResult.new(stdout: passwd.name, stderr: '', exit_status: 0)
-      rescue => e
-        Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
 
       def get_file_owner_group(path)
         gid = File.stat(path).gid
         group = Etc.getgrgid(gid)
         Specinfra::CommandResult.new(stdout: group.name, stderr: '', exit_status: 0)
-      rescue => e
-        Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
     end
   end

--- a/mrblib/mitamae/inline_backends/file_backend.rb
+++ b/mrblib/mitamae/inline_backends/file_backend.rb
@@ -16,18 +16,24 @@ module MItamae
       def get_file_mode(path)
         mode_str = sprintf('%04o', File.stat(path).mode & 07777)
         Specinfra::CommandResult.new(stdout: mode_str, stderr: '', exit_status: 0)
+      rescue SystemCallError => e
+        Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
 
       def get_file_owner_user(path)
         uid = File.stat(path).uid
         passwd = Etc.getpwuid(uid)
         Specinfra::CommandResult.new(stdout: passwd.name, stderr: '', exit_status: 0)
+      rescue SystemCallError => e
+        Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
 
       def get_file_owner_group(path)
         gid = File.stat(path).gid
         group = Etc.getgrgid(gid)
         Specinfra::CommandResult.new(stdout: group.name, stderr: '', exit_status: 0)
+      rescue SystemCallError => e
+        Specinfra::CommandResult.new(stdout: '', stderr: e.message, exit_status: 1)
       end
     end
   end


### PR DESCRIPTION
`run_command(:get_file_owner_user, path)` was raising an exception when
the underlying stat command failed. So the inline backends should raise
an exception on error cases.

https://github.com/k0kubun/mitamae/pull/32/files#r91998048
@k0kubun what do you think?