### PR TITLE
Set updated flag in dry-run mode

### DIFF
--- a/mrblib/mitamae/resource_executor/base.rb
+++ b/mrblib/mitamae/resource_executor/base.rb
@@ -73,9 +73,8 @@ module MItamae
             MItamae.logger.error "action #{action.inspect} is unavailable"
             exit 1
           end
-          return if @runner.dry_run?
 
-          apply
+          apply unless @runner.dry_run?
           if different?
             updated!
           end


### PR DESCRIPTION
I'd like to see actions triggered by notifications in dry-run mode.
That behavior is compatible with itamae.

```ruby
execute 'true' do
  action :nothing
end

file '/tmp/test.txt' do
  notifies :run, 'execute[true]'
end
```

Before

```
% mitamae local test.rb --dry-run
INFO : Starting MItamae...
INFO : Recipe: /home/eagletmt/.ghq/github.com/k0kubun/mitamae/test.rb
INFO :   file[/tmp/test.txt] exist will change from 'false' to 'true'
```

After

```
% mitamae local test.rb --dry-run
INFO : Starting MItamae...
INFO : Recipe: /home/eagletmt/.ghq/github.com/k0kubun/mitamae/test.rb
INFO :   file[/tmp/test.txt] exist will change from 'false' to 'true'
INFO :   Notifying run to execute resource 'true' (delayed)
INFO :   execute[true] executed will change from 'false' to 'true'
```