### PR TITLE
Fix bug in remote_directory resource when desired directory exists

### DIFF
--- a/mrblib/mitamae/resource_executor/remote_directory.rb
+++ b/mrblib/mitamae/resource_executor/remote_directory.rb
@@ -59,7 +59,9 @@ module MItamae
         super
 
         if current.exist
-          diff = run_command(["diff", "-u", attributes.path, @temppath], error: false)
+          temppath = ::File.join('/tmp', Time.now.to_f.to_s)
+          run_command(['cp', '-r', ::File.join(@resource.recipe.dir, desired.source), temppath])
+          diff = run_command(["diff", "-u", attributes.path, temppath], error: false)
           if diff.exit_status == 0
             # no change
             MItamae.logger.debug "directory content will not change"

--- a/mrblib/mitamae/resource_executor/remote_directory.rb
+++ b/mrblib/mitamae/resource_executor/remote_directory.rb
@@ -59,7 +59,6 @@ module MItamae
         super
 
         if current.exist
-          run_command(['cp', '-r', ::File.join(@resource.recipe.dir, desired.source), temppath])
           diff = run_command(["diff", "-u", attributes.path, ::File.join(@resource.recipe.dir, desired.source)], error: false)
           if diff.exit_status == 0
             # no change

--- a/mrblib/mitamae/resource_executor/remote_directory.rb
+++ b/mrblib/mitamae/resource_executor/remote_directory.rb
@@ -59,9 +59,8 @@ module MItamae
         super
 
         if current.exist
-          temppath = ::File.join('/tmp', Time.now.to_f.to_s)
           run_command(['cp', '-r', ::File.join(@resource.recipe.dir, desired.source), temppath])
-          diff = run_command(["diff", "-u", attributes.path, temppath], error: false)
+          diff = run_command(["diff", "-u", attributes.path, ::File.join(@resource.recipe.dir, desired.source)], error: false)
           if diff.exit_status == 0
             # no change
             MItamae.logger.debug "directory content will not change"

--- a/spec/integration/remote_directory_spec.rb
+++ b/spec/integration/remote_directory_spec.rb
@@ -13,4 +13,20 @@ describe 'remote_directory resource' do
     it { should be_file }
     its(:content) { should eq("Hello\n") }
   end
+
+  context 'when desired directory exists' do
+    before(:all) do
+      apply_recipe('remote_directory')
+      apply_recipe('remote_directory') # Do twice
+    end
+
+    describe file('/tmp/remdir') do
+      it { should be_directory }
+    end
+  
+    describe file('/tmp/remdir/file') do
+      it { should be_file }
+      its(:content) { should eq("Hello\n") }
+    end
+  end
 end


### PR DESCRIPTION
remote_direcotry resource crashes in show_defferences because of lack of `@temppath`.

```
% mitamae local -ldebug spec/recipes/remote_directory.rb
 INFO : Starting MItamae...
 INFO : Recipe: /Users/makimoto/.ghq/github.com/k0kubun/mitamae/spec/recipes/remote_directory.rb
DEBUG :   remote_directory[/tmp/remdir]
DEBUG :     remote_directory[/tmp/remdir] action: create
DEBUG :       (in set_desired_attributes)
DEBUG :       (in set_current_attributes)
DEBUG :       (in pre_action)
DEBUG :       (in show_differences)
 INFO :       remote_directory[/tmp/remdir] exist will change from 'false' to 'true'
DEBUG :       Executing `cp -r /Users/makimoto/.ghq/github.com/k0kubun/mitamae/spec/recipes/remdir /tmp/remdir`...
DEBUG :         exited with 0
DEBUG :       This resource is updated.
% mitamae local -ldebug spec/recipes/remote_directory.rb
 INFO : Starting MItamae...
 INFO : Recipe: /Users/makimoto/.ghq/github.com/k0kubun/mitamae/spec/recipes/remote_directory.rb
DEBUG :   remote_directory[/tmp/remdir]
DEBUG :     remote_directory[/tmp/remdir] action: create
DEBUG :       (in set_desired_attributes)
DEBUG :       (in set_current_attributes)
DEBUG :       (in pre_action)
DEBUG :       (in show_differences)
DEBUG :       remote_directory[/tmp/remdir] exist will not change (current value is 'true')
DEBUG :       remote_directory[/tmp/remdir] mode will not change (current value is '0755')
DEBUG :       remote_directory[/tmp/remdir] owner will not change (current value is 'makimoto')
DEBUG :       remote_directory[/tmp/remdir] group will not change (current value is 'wheel')
DEBUG :       Executing `diff -u /tmp/remdir ''`...
trace:
	[0] /home/mruby/code/mruby/build/mrbgems/mruby-open3/mrblib/mrb_open3.rb:13:in Open3#capture3
	[1] /home/mruby/code/mrblib/mitamae/backend.rb:110:in MItamae::Backend.run_with_open3
	[2] /home/mruby/code/mrblib/mitamae/backend.rb:18:in MItamae::Backend.run_command
	[3] /home/mruby/code/mrblib/mitamae/runner.rb:15:in MItamae::Runner.run_command
	[4] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:154:in MItamae::ResourceExecutor::Base.run_command
	[5] /home/mruby/code/mrblib/mitamae/resource_executor/remote_directory.rb:62:in MItamae::ResourceExecutor::RemoteDirectory.show_differences
	[6] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:69:in MItamae::ResourceExecutor::Base.run_action
	[7] /home/mruby/code/mrblib/mitamae/logger.rb:104:in MItamae::Logger.with_indent_if
	[8] /home/mruby/code/mrblib/mitamae/logger.rb:97:in MItamae::Logger.with_indent
	[9] /home/mruby/code/mrblib/mitamae/logger.rb:104:in MItamae::Logger.with_indent_if
	[10] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:58:in MItamae::ResourceExecutor::Base.run_action
	[11] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:17:in MItamae::ResourceExecutor::Base.execute
	[12] /home/mruby/code/mruby/mrblib/array.rb:17:in Array.each
	[13] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:16:in MItamae::ResourceExecutor::Base.execute
	[14] /home/mruby/code/mrblib/mitamae/logger.rb:104:in MItamae::Logger.with_indent_if
	[15] /home/mruby/code/mrblib/mitamae/logger.rb:97:in MItamae::Logger.with_indent
	[16] /home/mruby/code/mrblib/mitamae/logger.rb:104:in MItamae::Logger.with_indent_if
	[17] /home/mruby/code/mrblib/mitamae/resource_executor/base.rb:13:in MItamae::ResourceExecutor::Base.execute
	[18] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:24:in MItamae::RecipeExecutor.execute_node
	[19] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:33:in MItamae::RecipeExecutor.execute_children
	[20] /home/mruby/code/mruby/mrblib/array.rb:17:in Array.each
	[21] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:32:in MItamae::RecipeExecutor.execute_children
	[22] /home/mruby/code/mrblib/mitamae/logger.rb:97:in MItamae::Logger.with_indent
	[23] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:31:in MItamae::RecipeExecutor.execute_children
	[24] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:19:in MItamae::RecipeExecutor.execute_node
	[25] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:9:in MItamae::RecipeExecutor.execute
	[26] /home/mruby/code/mruby/mrblib/array.rb:17:in Array.each
	[27] /home/mruby/code/mrblib/mitamae/recipe_executor.rb:8:in MItamae::RecipeExecutor.execute
	[28] /home/mruby/code/mrblib/mitamae/cli/local.rb:38:in MItamae::CLI::Local.run
	[29] /home/mruby/code/mrblib/mitamae/cli.rb:17:in MItamae::CLI.run
	[30] /home/mruby/code/mrblib/mitamae/cli.rb:4:in MItamae::CLI#start
	[31] /home/mruby/code/mrblib/mitamae.rb:2:in Object.__main__
/home/mruby/code/mruby/build/mrbgems/mruby-open3/mrblib/mrb_open3.rb:13: expected String (TypeError)
```