### PR TITLE
Accept callable object as only_if/not_if command

### DIFF
--- a/mrblib/mitamae/resource_context.rb
+++ b/mrblib/mitamae/resource_context.rb
@@ -19,12 +19,24 @@ module MItamae
       @resource.subscriptions << Subscription.create(@resource, action, resource_desc, timing)
     end
 
-    def not_if(command)
-      @resource.not_if_command = command
+    def not_if(command = nil, &block)
+      if block
+        @resource.not_if_command = block
+      elsif command
+        @resource.not_if_command = command
+      else
+        raise ArgumentError, 'not_if requires command or block'
+      end
     end
 
-    def only_if(command)
-      @resource.only_if_command = command
+    def only_if(command = nil, &block)
+      if block
+        @resource.only_if_command = block
+      elsif command
+        @resource.only_if_command = command
+      else
+        raise ArgumentError, 'only_if requires command or block'
+      end
     end
 
     def verify(command)

--- a/mrblib/mitamae/resource_executor/base.rb
+++ b/mrblib/mitamae/resource_executor/base.rb
@@ -41,14 +41,22 @@ module MItamae
       attr_reader :desired
 
       def skip_condition?
-        if @resource.only_if_command && run_command(@resource.only_if_command, error: false).exit_status != 0
+        if @resource.only_if_command && !run_condition_command(@resource.only_if_command)
           MItamae.logger.debug "#{@resource.resource_type}[#{@resource.resource_name}] Execution skipped because of only_if attribute"
           true
-        elsif @resource.not_if_command && run_command(@resource.not_if_command, error: false).exit_status == 0
+        elsif @resource.not_if_command && run_condition_command(@resource.not_if_command)
           MItamae.logger.debug "#{@resource.resource_type}[#{@resource.resource_name}] Execution skipped because of not_if attribute"
           true
         else
           false
+        end
+      end
+
+      def run_condition_command(command)
+        if command.respond_to?(:call)
+          command.call
+        else
+          run_command(command, error: false).exit_status == 0
         end
       end
 

--- a/spec/integration/execute_spec.rb
+++ b/spec/integration/execute_spec.rb
@@ -17,4 +17,12 @@ describe 'execute resource' do
   describe file('/tmp/never_exist2') do
     it { should_not be_file }
   end
+
+  describe file('/tmp/never_exist3') do
+    it { should_not be_file }
+  end
+
+  describe file('/tmp/never_exist4') do
+    it { should_not be_file }
+  end
 end

--- a/spec/recipes/file.rb
+++ b/spec/recipes/file.rb
@@ -15,6 +15,14 @@ file "/tmp/never_exist2" do
   not_if "exit 0"
 end
 
+file "/tmp/never_exist3" do
+  only_if { false }
+end
+
+file "/tmp/never_exist4" do
+  not_if { true }
+end
+
 ###
 
 file "/tmp/never_exist4" do


### PR DESCRIPTION
It allows inlining only_if/not_if conditions.

Example:

```ruby
execute 'git clone https://github.com/k0kubun/mitamae' do
  not_if { FileTest.directory?('mitamae') }
end
```