### PR TITLE
Set all current attributes regardless of action attribute

### DIFF
--- a/mrblib/mitamae/resource_executor/service.rb
+++ b/mrblib/mitamae/resource_executor/service.rb
@@ -35,16 +35,10 @@ module MItamae
       private
 
       def set_current_attributes(current, action)
-        case action
-        when :start, :stop
-          current.running = run_specinfra(:"check_service_is_running#{@under}", attributes.name)
-        when :restart
-          current.restarted = false
-        when :reload
-          current.reloaded = false
-        when :enable, :disable
-          current.enabled = run_specinfra(:"check_service_is_enabled#{@under}", attributes.name)
-        end
+        current.running = run_specinfra(:"check_service_is_running#{@under}", attributes.name)
+        current.enabled = run_specinfra(:"check_service_is_enabled#{@under}", attributes.name)
+        current.restarted = false
+        current.reloaded = false
       end
 
       def set_desired_attributes(desired, action)


### PR DESCRIPTION
`action` is set not only from `action` attribute in resource definitions
but from notifications.

```ruby
file '/tmp/hoge.txt' do
  content "#{Time.now.to_i}\n"
  notifies :reload, 'service[nginx]'
end

service 'nginx'
```

In this example, applying this recipe is expected to reload nginx, but
it isn't because `current.running` isn't initialized. All current
attributes should be initialized regardless of `action` attribute.