### PR TITLE
Support depth attribute to git resource

### DIFF
--- a/mrblib/mitamae/resource/git.rb
+++ b/mrblib/mitamae/resource/git.rb
@@ -6,6 +6,7 @@ module MItamae
       define_attribute :repository, type: String, required: true
       define_attribute :revision, type: String
       define_attribute :recursive, type: [TrueClass, FalseClass], default: false
+      define_attribute :depth, type: Integer, default: false
 
       self.available_actions = [:sync]
     end

--- a/mrblib/mitamae/resource_executor/git.rb
+++ b/mrblib/mitamae/resource_executor/git.rb
@@ -11,6 +11,7 @@ module MItamae
         if check_empty_dir
           cmd = ['git', 'clone']
           cmd << '--recursive' if desired.recursive
+          cmd += ['--depth', attributes.depth.to_s] if attributes.depth
           cmd << desired.repository << desired.destination
           run_command(cmd)
           new_repository = true
@@ -95,4 +96,3 @@ module MItamae
     end
   end
 end
-

--- a/spec/integration/git_spec.rb
+++ b/spec/integration/git_spec.rb
@@ -12,4 +12,8 @@ describe 'git resource' do
   describe command('cd /tmp/git_repo_submodule/empty_repo && cat README.md') do
     its(:stdout) { should match(/Empty Repo/) }
   end
+
+  describe command('cd /tmp/fake_depth_repo && git rev-list --count HEAD') do
+    its(:stdout) { should eq "1\n" }
+  end
 end

--- a/spec/recipes/git.rb
+++ b/spec/recipes/git.rb
@@ -7,3 +7,8 @@ git "/tmp/git_repo_submodule" do
   repository "https://github.com/mmasaki/fake_repo_including_submodule.git"
   recursive true
 end
+
+git "/tmp/fake_depth_repo" do
+  repository "https://github.com/hatappi/fake_depth_repo.git"
+  depth 1
+end


### PR DESCRIPTION
I used Itamae, but use MItamae now.

Itamae can execute below code.
```ruby
git "/tmp/fake_depth_repo" do
  repository "https://github.com/hatappi/fake_depth_repo.git"
  depth 1
end
# git clone --depth 1 https://github.com/hatappi/fake_depth_repo.git
```
ref: https://github.com/itamae-kitchen/itamae/blob/master/lib/itamae/resource/git.rb#L13

But MItamae cannot use this.
I want to use `--depth` option.
For example [neologd/mecab-ipadic-neologd](https://github.com/neologd/mecab-ipadic-neologd) install.