### PR TITLE
Migrate docker-compse.yml to v2 format

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,13 @@
-compile: &defaults
-  build: .
-  volumes:
-    - .:/home/mruby/code:rw
-  command: rake compile
-clean:
-  <<: *defaults
-  command: rake clean
-shell:
-  <<: *defaults
-  command: bash
+version: '2'
+services:
+  compile: &defaults
+    build: .
+    volumes:
+      - .:/home/mruby/code:rw
+    command: rake compile
+  clean:
+    <<: *defaults
+    command: rake clean
+  shell:
+    <<: *defaults
+    command: bash


### PR DESCRIPTION
v3 is the currently recommended format, but the difference between v2
and v3 doesn't have compatibility impact on mitamae spec.
https://docs.docker.com/compose/compose-file/compose-versioning/